### PR TITLE
add webkit prefixed clip-path property

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -124,5 +124,6 @@
 	background-color: #389d10;
 	padding: 8px;
 	transform: scale(0.6);
+	-webkit-clip-path: circle(23px at center);
 	clip-path: circle(23px at center);
 }


### PR DESCRIPTION
Fixes `clip-path` on iOS Safari

## Before
![img_1895](https://user-images.githubusercontent.com/11544418/52534498-1e3a4880-2d3a-11e9-9cf1-9bad0551e8de.PNG)

## After

![img_1894](https://user-images.githubusercontent.com/11544418/52534500-21cdcf80-2d3a-11e9-9c74-8c370d2d1bef.PNG)

